### PR TITLE
Add rules for engine target to change lib path by OS

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,12 @@ cc_binary(
   deps = [
     "@com_github_sdl//:sdl3_shared",
     ":game",
-  ]
+  ],
+  defines = select({
+    "@bazel_tools//src/conditions:darwin": ['GAME_LIB_PATH="\\"./libgame.dylib\\""'],
+    "@bazel_tools//src/conditions:linux": ['GAME_LIB_PATH="\\"./libgame.so\\""'],
+    "@bazel_tools//src/conditions:windows": ['GAME_LIB_PATH="\\"./game.dll\\""'],
+  })
 )
 
 cc_binary(

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -7,6 +7,10 @@
 #include <cstdio>
 #include <cstdlib>
 
+#ifndef GAME_LIB_PATH
+#define GAME_LIB_PATH "libgame.so"
+#endif
+
 SDL_AppResult engine_init(const int width, const int height, const char *title,
                           struct AppState *state) {
   auto setMetadata =
@@ -36,7 +40,7 @@ SDL_AppResult engine_init(const int width, const int height, const char *title,
 
   state->game->isValid = false;
 
-  state->game->game_object = SDL_LoadObject("./libgame.so");
+  state->game->game_object = SDL_LoadObject(GAME_LIB_PATH);
   if (state->game->game_object == nullptr) {
     SDL_Log("Failed to load game code: %s", SDL_GetError());
     return SDL_APP_FAILURE;


### PR DESCRIPTION
This PR should correctly check the host OS during compilation of the `:engine` target, fixing non-Linux builds. Hopefully.

Supposed to fix #6 after #7 got us part of the way there.