### PR TITLE
Fix MacOS builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,7 @@
 load("@emsdk//emscripten_toolchain:wasm_rules.bzl", "wasm_cc_binary")
 
 cc_library(
-  name = "game",
-  srcs = glob(["src/game.*"]),
+  name = "game_headers",
   hdrs = [
     "src/game.h"
   ],
@@ -12,12 +11,21 @@ cc_library(
 )
 
 cc_binary(
+  name = "game",
+  srcs = glob(["src/game.*"]),
+  deps = [
+    ":game_headers",
+  ],
+  linkshared = True,
+)
+
+cc_binary(
   name = "engine",
   data = [":game"],
   srcs = glob(["src/engine.*", "src/main.cpp"]),
   deps = [
     "@com_github_sdl//:sdl3_shared",
-    ":game",
+    ":game_headers",
   ]
 )
 

--- a/BUILD
+++ b/BUILD
@@ -26,7 +26,12 @@ cc_binary(
   deps = [
     "@com_github_sdl//:sdl3_shared",
     ":game_headers",
-  ]
+  ],
+  defines = select({
+    "@bazel_tools//src/conditions:darwin": ['GAME_LIB_PATH=\\"./libgame.dylib\\"'],
+    "@bazel_tools//src/conditions:linux": ['GAME_LIB_PATH=\\"./libgame.so\\"'],
+    "@bazel_tools//src/conditions:windows": ['GAME_LIB_PATH=\\".\\game.dll\\"'],
+  })
 )
 
 cc_binary(

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -34,19 +34,19 @@ SDL_AppResult engine_init(const int width, const int height, const char *title,
 
   state->game->isValid = false;
 
-  state->game->game_object = SDL_LoadObject("./libgame.dylib");
+  state->game->game_object = SDL_LoadObject(state->game->path);
   if (state->game->game_object == nullptr) {
     SDL_Log("Failed to load game code: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
-  
+
   state->game->game_init =
       GameInit(SDL_LoadFunction(state->game->game_object, "game_init"));
   if (state->game->game_init == nullptr) {
     SDL_Log("Failed to load game_init: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
-  
+
   state->game->game_update =
       GameUpdate(SDL_LoadFunction(state->game->game_object, "game_update"));
   if (state->game->game_update == nullptr) {
@@ -89,19 +89,19 @@ SDL_AppResult engine_rebuild_reload_game(struct AppState *state) {
     return SDL_APP_FAILURE;
   }
 
-  state->game->game_object = SDL_LoadObject("./libgame.dylib");
+  state->game->game_object = SDL_LoadObject(state->game->path);
   if (state->game->game_object == nullptr) {
     SDL_Log("Failed to load game code: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
-  
+
   state->game->game_init =
       GameInit(SDL_LoadFunction(state->game->game_object, "game_init"));
   if (state->game->game_init == nullptr) {
     SDL_Log("Failed to load game_init: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
-  
+
   state->game->game_update =
       GameUpdate(SDL_LoadFunction(state->game->game_object, "game_update"));
   if (state->game->game_update == nullptr) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -32,21 +32,29 @@ SDL_AppResult engine_init(const int width, const int height, const char *title,
     return SDL_APP_FAILURE;
   }
 
-  game_init(&state->gameState);
-
   state->game->isValid = false;
 
-  state->game->game_object = SDL_LoadObject("./libgame.so");
+  state->game->game_object = SDL_LoadObject("./libgame.dylib");
   if (state->game->game_object == nullptr) {
     SDL_Log("Failed to load game code: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
+  
+  state->game->game_init =
+      GameInit(SDL_LoadFunction(state->game->game_object, "game_init"));
+  if (state->game->game_init == nullptr) {
+    SDL_Log("Failed to load game_init: %s", SDL_GetError());
+    return SDL_APP_FAILURE;
+  }
+  
   state->game->game_update =
       GameUpdate(SDL_LoadFunction(state->game->game_object, "game_update"));
   if (state->game->game_update == nullptr) {
     SDL_Log("Failed to load game_update: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
+
+  state->game->game_init(&state->gameState);
 
   state->game->isValid = true;
 
@@ -81,11 +89,19 @@ SDL_AppResult engine_rebuild_reload_game(struct AppState *state) {
     return SDL_APP_FAILURE;
   }
 
-  state->game->game_object = SDL_LoadObject("./libgame.so");
+  state->game->game_object = SDL_LoadObject("./libgame.dylib");
   if (state->game->game_object == nullptr) {
     SDL_Log("Failed to load game code: %s", SDL_GetError());
     return SDL_APP_FAILURE;
   }
+  
+  state->game->game_init =
+      GameInit(SDL_LoadFunction(state->game->game_object, "game_init"));
+  if (state->game->game_init == nullptr) {
+    SDL_Log("Failed to load game_init: %s", SDL_GetError());
+    return SDL_APP_FAILURE;
+  }
+  
   state->game->game_update =
       GameUpdate(SDL_LoadFunction(state->game->game_object, "game_update"));
   if (state->game->game_update == nullptr) {
@@ -101,6 +117,7 @@ SDL_AppResult engine_rebuild_reload_game(struct AppState *state) {
 void engine_free_code_instance(struct Game *game) {
   SDL_Log("Free and reset game code - start");
   SDL_UnloadObject(game->game_object);
+  game->game_init = nullptr;
   game->game_update = nullptr;
   game->game_object = nullptr;
   game->isValid = false;
@@ -116,7 +133,7 @@ SDL_AppResult engine_update(struct AppState *appState) {
 
   if (game->isValid) {
     // SDL_Log("Game update - start");
-    game->game_update(r_context->renderer, &(appState->gameState));
+    game->game_update(r_context->renderer, appState->gameState);
     // SDL_Log("Game update - finish");
   }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -5,7 +5,8 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_init.h>
 
-typedef void (*GameUpdate)(SDL_Renderer *renderer, GameState **gameState);
+typedef void (*GameUpdate)(SDL_Renderer *renderer, GameState *gameState);
+typedef void (*GameInit)(GameState **gameState);
 
 struct RenderContext {
   SDL_Window *window;
@@ -17,6 +18,7 @@ struct Game {
   const char *path;
   SDL_SharedObject *game_object;
   GameUpdate game_update;
+  GameInit game_init;
 };
 
 struct AppState {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,16 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 
+#ifndef GAME_LIB_PATH
+#define GAME_LIB_PATH ""
+#endif
+
 static SDL_Window *window = NULL;
 
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[]) {
   struct RenderContext *r_context = new RenderContext{nullptr, nullptr};
 
-  struct Game *game = new Game{false, "game.so", nullptr, nullptr, nullptr};
+  struct Game *game = new Game{false, GAME_LIB_PATH, nullptr, nullptr, nullptr};
 
   *appstate = new AppState;
   AppState &state = *static_cast<AppState *>(*appstate);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ static SDL_Window *window = NULL;
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[]) {
   struct RenderContext *r_context = new RenderContext{nullptr, nullptr};
 
-  struct Game *game = new Game{false, "game.so", nullptr, nullptr};
+  struct Game *game = new Game{false, "game.so", nullptr, nullptr, nullptr};
 
   *appstate = new AppState;
   AppState &state = *static_cast<AppState *>(*appstate);


### PR DESCRIPTION
# Summary

This PR introduces _The Vibes_ to this project to fix Mac OS builds, and adds conditionally pointing to the appropriate library path extension for the `//:engine` target. In other words, Darwin engine builds point to a `dylib`, Linux builds point to a `so`, and Windows builds point to a `dll`.

# Shout-outs

Thanks to @jwhpryor for the vibe fix, and also for forcing me to actually work on the Mac OS builds, which got me learning about the differences in Linux and Mac OS build processes! I still don't fully understand it but I get the gist I think :p